### PR TITLE
Adds logging to the secop-opohyd integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv
+.secop_ophyd
 *.pyc
 *.egg-info
 .pytest_cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,11 @@
 .venv
-.secop_ophyd
 *.pyc
 *.egg-info
 .pytest_cache
-secop_ophyd/asyncclient.log
 build
 dist
 .env
 **/_version.py
 pid
 logs
+.secop-ophyd

--- a/src/secop_ophyd/logs.py
+++ b/src/secop_ophyd/logs.py
@@ -1,0 +1,124 @@
+import logging
+import sys
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Optional
+
+# Default configuration
+DEFAULT_LOG_LEVEL = logging.INFO
+DEFAULT_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+DEFAULT_LOG_DIR = ".secop-ophyd"
+DEFAULT_LOG_FILENAME = "secop-ophyd.log"
+DEFAULT_MAX_BYTES = 100 * 1024 * 1024  # 10 MB
+DEFAULT_BACKUP_COUNT = 5
+
+# Create a dictionary of log level names to their values
+LOG_LEVELS = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARNING": logging.WARNING,
+    "ERROR": logging.ERROR,
+    "CRITICAL": logging.CRITICAL,
+}
+
+
+def setup_logging(
+    name: str = "secop_ophyd",
+    level: int = DEFAULT_LOG_LEVEL,
+    log_format: str = DEFAULT_LOG_FORMAT,
+    log_dir: Optional[str] = None,
+    log_file: Optional[str] = None,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+    backup_count: int = DEFAULT_BACKUP_COUNT,
+    console: bool = False,
+) -> logging.Logger:
+    """
+    Set up and configure a logger with rotating file handler.
+
+    Parameters:
+    ----------
+    name : str
+        Name of the logger
+    level : int
+        Logging level (default: INFO)
+    log_format : str
+        Format string for log messages
+    log_dir : Optional[str]
+        Directory to store log files (default: ~/.secop-ophyd/logs)
+    log_file : Optional[str]
+        Log file name (default: secop-ophyd.log)
+    max_bytes : int
+        Maximum size of log file before rotation (default: 10 MB)
+    backup_count : int
+        Number of backup files to keep (default: 5)
+    console : bool
+        Whether to also log to console (default: True)
+
+    Returns:
+    -------
+    logging.Logger
+        Configured logger instance
+    """
+    # Create logger
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+
+    # If handlers already exist, don't add more
+    if logger.handlers:
+        return logger
+
+    # Create formatter
+    formatter = logging.Formatter(log_format)
+
+    # Set up log directory
+    if log_dir is None:
+        log_dir = DEFAULT_LOG_DIR
+
+    log_path = Path(log_dir)
+    log_path.mkdir(parents=True, exist_ok=True)
+
+    # Set up log file path
+    if log_file is None:
+        log_file = DEFAULT_LOG_FILENAME
+
+    log_file_path = log_path / log_file
+
+    # Create rotating file handler
+    file_handler = RotatingFileHandler(
+        log_file_path, maxBytes=max_bytes, backupCount=backup_count
+    )
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    # Add console handler if requested
+    if console:
+        console_handler = logging.StreamHandler(sys.stdout)
+        console_handler.setFormatter(formatter)
+        logger.addHandler(console_handler)
+
+    logger.info(f"Logging initialized: {log_file_path}")
+    return logger
+
+
+def get_logger(name: str) -> logging.Logger:
+    """
+    Get a logger by name. If the logger doesn't exist, it will be created
+    with default settings.
+
+    Parameters:
+    ----------
+    name : str
+        Name of the logger
+
+    Returns:
+    -------
+    logging.Logger
+        Logger instance
+    """
+    logger = logging.getLogger(name)
+
+    # If the logger doesn't have handlers, set it up with defaults
+    if not logger.handlers:
+        return setup_logging(name)
+
+    return logger

--- a/src/secop_ophyd/logs.py
+++ b/src/secop_ophyd/logs.py
@@ -9,7 +9,7 @@ DEFAULT_LOG_LEVEL = logging.INFO
 DEFAULT_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 DEFAULT_LOG_DIR = ".secop-ophyd"
 DEFAULT_LOG_FILENAME = "secop-ophyd.log"
-DEFAULT_ROTATION_WHEN = "H"  # Rotate every hour
+DEFAULT_ROTATION_WHEN = "M"  # Rotate every hour
 DEFAULT_ROTATION_INTERVAL = 1  # Every 1 hour
 DEFAULT_BACKUP_COUNT = 48  # Keep logs for 48 hours
 

--- a/src/secop_ophyd/logs.py
+++ b/src/secop_ophyd/logs.py
@@ -9,7 +9,7 @@ DEFAULT_LOG_LEVEL = logging.INFO
 DEFAULT_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 DEFAULT_LOG_DIR = ".secop-ophyd"
 DEFAULT_LOG_FILENAME = "secop-ophyd.log"
-DEFAULT_ROTATION_WHEN = "M"  # Rotate every hour
+DEFAULT_ROTATION_WHEN = "H"  # Rotate every hour
 DEFAULT_ROTATION_INTERVAL = 1  # Every 1 hour
 DEFAULT_BACKUP_COUNT = 48  # Keep logs for 48 hours
 

--- a/src/secop_ophyd/util.py
+++ b/src/secop_ophyd/util.py
@@ -4,7 +4,6 @@ import copy
 import time
 import warnings
 from abc import ABC, abstractmethod
-from enum import Enum
 from functools import reduce
 from itertools import chain
 from typing import Any, List, Union
@@ -36,34 +35,6 @@ SCALAR_DATATYPES = (
     StringType,
     EnumType,
 )
-
-
-class Role(Enum):
-    USER = 0
-    ADVANCED = 1
-    EXPERT = 2
-
-
-class Access(Enum):
-    NO_ACCESS = 0
-    READ = 1
-    WRITE = 2
-
-
-def get_access_level(role: Role, accessmode: str) -> Access:
-    assert len(accessmode) == 3
-
-    access_str = accessmode[role.value]
-
-    match access_str:
-        case "r":
-            return Access.READ
-        case "w":
-            return Access.WRITE
-        case "-":
-            return Access.NO_ACCESS
-        case _:
-            raise Exception(f"unknown accces level: {accessmode[role.value]}")
 
 
 class NestedRaggedArray(Exception):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,7 +176,10 @@ def nested_node_re(run_engine):
 @pytest.fixture
 async def cryo_node_internal_loop():
     return await SECoPNodeDevice.create_async(
-        host="localhost", port="10769", loop=asyncio.get_running_loop()
+        host="localhost",
+        port="10769",
+        loop=asyncio.get_running_loop(),
+        loglevel="DEBUG",
     )
 
 


### PR DESCRIPTION
- Logging level can be specified individually for each instantiated SEC node,
   - loglevel: `INFO`: some secop-ophyd internals are logged
   - loglevel: `DEBUG`: all messages rent (TX) and received (RX) by the frappy-client are logged
- logs are written into .secop-ophyd/secop-ophyd.log
- logs rotate every hour, and are kept for the last 48h

``` python
# Connect to Gas Dosing SEC Node and generate ophyd device tree
gas_dosing =  SECoPNodeDevice.create('localhost','10800',RE.loop,loglevel="DEBUG")

# Connect to Reactor Cell SEC Node and generate ophyd device tree
reactor_cell =  SECoPNodeDevice.create('localhost','10801',RE.loop,loglevel="INFO")
``