### PR TITLE
migrate to v0.13.3

### DIFF
--- a/src/secop_ophyd/SECoPDevices.py
+++ b/src/secop_ophyd/SECoPDevices.py
@@ -442,12 +442,6 @@ class SECoPBaseDevice(StandardReadable):
         else:
             setattr(self, sig_name, SignalRW(paramb))
 
-        def noop(val):
-            pass
-
-        sig: SignalR = getattr(self, sig_name)
-        sig.subscribe_value(noop)
-
 
 class SECoPCommunicatorDevice(SECoPBaseDevice):
 
@@ -574,7 +568,12 @@ class SECoPReadableDevice(SECoPCommunicatorDevice, Triggerable, Subscribable):
 
     def trigger(self) -> AsyncStatus:
         self.logger.info(f"Triggering {self.name}: read fresh data from device")
-        return AsyncStatus(awaitable=self.value.read(cached=False))
+        # get fresh reading of the value Parameter from the SEC Node
+        return AsyncStatus(
+            awaitable=self._secclient.get_parameter(
+                self._module, "value", trycache=False
+            )
+        )
 
     def subscribe(self, function: Callback[dict[str, Reading]]) -> None:
         """Subscribe to updates in the reading"""

--- a/src/secop_ophyd/SECoPSignal.py
+++ b/src/secop_ophyd/SECoPSignal.py
@@ -327,7 +327,7 @@ class SECoPParamBackend(SignalBackend):
 
     async def get_reading(self) -> Reading[SignalDatatypeT]:
         dataset = await self._secclient.get_parameter(
-            **self.get_param_path(), trycache=False
+            **self.get_param_path(), trycache=True
         )
 
         sec_reading = SECoPReading(entry=dataset, secop_dt=self.SECoP_type_info)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,7 +164,7 @@ async def cryo_node(run_engine):
 
 
 @pytest.fixture
-async def nested_node_re(run_engine):
+def nested_node_re(run_engine):
     return SECoPNodeDevice.create(host="localhost", port="10771", loop=run_engine.loop)
 
 

--- a/tests/test_Node.py
+++ b/tests/test_Node.py
@@ -66,6 +66,8 @@ async def test_signal_read_cached(cryo_sim, cryo_node_internal_loop: SECoPNodeDe
 
     cryo_dev: SECoPMoveableDevice = cryo_node_internal_loop.cryo
 
+    cryo_dev.p.subscribe_value(lambda val: None)
+
     p = await cryo_dev.p.get_value(cached=True)
 
     assert p == 40.0
@@ -79,15 +81,11 @@ async def test_signal_stage_unstage_read_cached(
 
     cryo_dev: SECoPMoveableDevice = cryo_node_internal_loop.cryo
 
-    await cryo_dev.value.stage()
-
-    await asyncio.sleep(1)
-
-    await cryo_dev.value.unstage()
-
-    await asyncio.sleep(1)
+    await cryo_dev.p.stage()
 
     p = await cryo_dev.p.get_value(cached=True)
+
+    await cryo_dev.p.unstage()
 
     assert p == 40.0
 
@@ -140,6 +138,10 @@ async def test_trigger(cryo_sim, cryo_node_internal_loop: SECoPNodeDevice):
 async def test_node_drive(cryo_sim, cryo_node_internal_loop: SECoPNodeDevice):
     cryo_dev: SECoPMoveableDevice = cryo_node_internal_loop.cryo
 
+    await cryo_dev.window.set(5)
+    await cryo_dev.tolerance.set(1)
+    await cryo_dev.ramp.set(20)
+
     target_old = await cryo_dev.target.read()
 
     new_target = 11.0
@@ -156,7 +158,7 @@ async def test_node_drive(cryo_sim, cryo_node_internal_loop: SECoPNodeDevice):
 
     reading = await cryo_dev.value.get_value()
 
-    assert np.isclose(reading, new_target, atol=0.2)
+    assert np.isclose(reading, new_target, atol=1.0)
 
     await cryo_node_internal_loop.disconnect_async()
 

--- a/tests/test_primitive_arrays.py
+++ b/tests/test_primitive_arrays.py
@@ -9,7 +9,7 @@ from ophyd_async.core import SignalR
 from secop_ophyd.SECoPDevices import SECoPNodeDevice, SECoPReadableDevice
 
 
-async def test_primitive_arrays(
+def test_primitive_arrays(
     nested_struct_sim, run_engine: RunEngine, nested_node_re: SECoPNodeDevice
 ):
     bec = BestEffortCallback()


### PR DESCRIPTION
- fixes issue, where signal subscriptions coul dnot happen outside of a running eventloop
- cached values are now read from the frappy cache
- trigger on a `Readable`  device sends a read request to the hardware    