### PR TITLE
Remove status from readables

### DIFF
--- a/src/secop_ophyd/SECoPDevices.py
+++ b/src/secop_ophyd/SECoPDevices.py
@@ -77,7 +77,8 @@ ERROR_PREPARED = 450
 UNKNOWN = 401  # not in SECoP standard (yet)
 
 
-READABLE_PARAMS = ["value", "target"]
+HINTED_PARAMS = ["value"]
+UNCACHED_PARAMS = ["target"]
 
 
 def clean_identifier(anystring):

--- a/src/secop_ophyd/SECoPDevices.py
+++ b/src/secop_ophyd/SECoPDevices.py
@@ -309,6 +309,25 @@ class SECoPBaseDevice(StandardReadable):
                 )
                 self.param_devices[parameter] = getattr(self, parameter)
 
+        # Add status Sigal (neither config nor read signal)
+        if "status" in module_desc["parameters"].keys():
+
+            properties = module_desc["parameters"][parameter]
+
+            # generate new root path
+            param_path = Path(parameter_name=parameter, module_name=module_name)
+
+            # readonly propertyns to plans and plan stubs.
+            readonly = properties.get("readonly", None)
+
+            # Normal types + (struct and tuple as JSON object Strings)
+            self._signal_from_parameter(
+                path=param_path,
+                sig_name=parameter,
+                readonly=readonly,
+            )
+            self.param_devices[parameter] = getattr(self, parameter)
+
         # Initialize Command Devices
         for command, properties in module_desc["commands"].items():
             # generate new root path

--- a/src/secop_ophyd/SECoPDevices.py
+++ b/src/secop_ophyd/SECoPDevices.py
@@ -77,7 +77,7 @@ ERROR_PREPARED = 450
 UNKNOWN = 401  # not in SECoP standard (yet)
 
 
-READABLE_PARAMS = ["value", "target", "status"]
+READABLE_PARAMS = ["value", "target"]
 
 
 def clean_identifier(anystring):

--- a/src/secop_ophyd/SECoPDevices.py
+++ b/src/secop_ophyd/SECoPDevices.py
@@ -312,10 +312,10 @@ class SECoPBaseDevice(StandardReadable):
         # Add status Sigal (neither config nor read signal)
         if "status" in module_desc["parameters"].keys():
 
-            properties = module_desc["parameters"][parameter]
+            properties = module_desc["parameters"]["status"]
 
             # generate new root path
-            param_path = Path(parameter_name=parameter, module_name=module_name)
+            param_path = Path(parameter_name="status", module_name=module_name)
 
             # readonly propertyns to plans and plan stubs.
             readonly = properties.get("readonly", None)
@@ -323,10 +323,10 @@ class SECoPBaseDevice(StandardReadable):
             # Normal types + (struct and tuple as JSON object Strings)
             self._signal_from_parameter(
                 path=param_path,
-                sig_name=parameter,
+                sig_name="status",
                 readonly=readonly,
             )
-            self.param_devices[parameter] = getattr(self, parameter)
+            self.param_devices["status"] = getattr(self, "status")
 
         # Initialize Command Devices
         for command, properties in module_desc["commands"].items():


### PR DESCRIPTION
- removes the status signal from the read signals group. this is needed as long as tiled is capable of injesting structured dtypes in the read signals